### PR TITLE
Tailwind Requires Assets to be deployed after Lib

### DIFF
--- a/lifecycle/Dockerfile
+++ b/lifecycle/Dockerfile
@@ -50,11 +50,11 @@ COPY priv priv
 # step down so that `lib` is available.
 COPY assets assets
 
-# compile assets
-RUN mix assets.deploy
-
 # Compile the release
 COPY lib lib
+
+# compile assets
+RUN mix assets.deploy
 
 RUN mix compile
 


### PR DESCRIPTION
Tailwind needs to have access to the lib/app_web directory to build the styles from your file patterns in the tailwind config. Since lib is copied after running assets.deploy in your docker file, it won’t see any of your files and thus won’t produce any included classes. Move that to after the deploy command and you are golden!